### PR TITLE
Harden upload flow and messaging resiliency with Portuguese localization

### DIFF
--- a/VisionaryAnalytics.Api/Options/UploadOptions.cs
+++ b/VisionaryAnalytics.Api/Options/UploadOptions.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace VisionaryAnalytics.Api.Options;
+
+public sealed class UploadOptions
+{
+    private static readonly string[] DefaultExtensions = [".mp4", ".avi"];
+
+    [Required]
+    [MinLength(1)]
+    public string RootPath { get; set; } = "/data/videos";
+
+    [Range(1, long.MaxValue)]
+    public long MaxFileSizeBytes { get; set; } = 524_288_000; // 500 MB
+
+    [MinLength(1)]
+    public List<string> AllowedExtensions { get; set; } = new(DefaultExtensions);
+
+    [JsonIgnore]
+    public IReadOnlySet<string> AllowedExtensionsSet { get; private set; } = new HashSet<string>(DefaultExtensions, StringComparer.OrdinalIgnoreCase);
+
+    public void Normalize()
+    {
+        RootPath = Path.GetFullPath(string.IsNullOrWhiteSpace(RootPath) ? "/data/videos" : RootPath);
+
+        AllowedExtensionsSet = AllowedExtensions
+            .Where(static ext => !string.IsNullOrWhiteSpace(ext))
+            .Select(static ext => ext.StartsWith('.') ? ext.ToLowerInvariant() : $".{ext.ToLowerInvariant()}")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (AllowedExtensionsSet.Count == 0)
+        {
+            throw new InvalidOperationException("Pelo menos uma extensão de arquivo deve ser permitida.");
+        }
+
+        AllowedExtensions = AllowedExtensionsSet.ToList();
+    }
+}

--- a/VisionaryAnalytics.Api/ProcessingHub.cs
+++ b/VisionaryAnalytics.Api/ProcessingHub.cs
@@ -5,11 +5,11 @@ namespace VisionaryAnalytics.Api;
 public class ProcessingHub : Hub
 {
     // Cliente pode entrar em um "grupo" por jobId para receber eventos
-    public Task SubscribeToJob(Guid jobId)
+    public Task InscreverNoJob(Guid jobId)
         => Groups.AddToGroupAsync(Context.ConnectionId, jobId.ToString());
 
     // Método chamado pelo Worker (via SignalR Client)
-    public async Task NotifyCompleted(Guid jobId, int resultsCount)
+    public async Task NotificarConclusao(Guid jobId, int resultsCount)
         => await Clients.Group(jobId.ToString())
-            .SendAsync("processingCompleted", new { jobId, resultsCount });
+            .SendAsync("processamentoConcluido", new { jobId, resultsCount });
 }

--- a/VisionaryAnalytics.Api/Program.cs
+++ b/VisionaryAnalytics.Api/Program.cs
@@ -1,93 +1,170 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 using VisionaryAnalytics.Api;
+using VisionaryAnalytics.Api.Options;
 using VisionaryAnalytics.Infrastructure.Interface;
 using VisionaryAnalytics.Infrastructure.Rabbit;
 using VisionaryAnalytics.Infrastructure.Redis;
 
 var builder = WebApplication.CreateBuilder(args);
-
-// Config
 var cfg = builder.Configuration;
-var uploadPath = cfg["UPLOAD_PATH"] ?? "/data/videos";
-Directory.CreateDirectory(uploadPath);
 
-// Redis
-builder.Services.AddSingleton<IConnectionMultiplexer>(_ =>
-    ConnectionMultiplexer.Connect(cfg["REDIS__CONNECTION"] ?? "redis:6379"));
-builder.Services.AddSingleton<IVideoJobStore, RedisVideoJobStore>();
-
-// RabbitMQ Publisher
-builder.Services.AddSingleton<IRabbitMqPublisher>(sp =>
-    new RabbitMqPublisher(new RabbitMqOptions
+builder.Services
+    .AddOptions<RabbitMqOptions>()
+    .BindConfiguration("RabbitMq")
+    .Configure(opt =>
     {
-        HostName = cfg["RABBITMQ__HOST"] ?? "rabbitmq",
-        UserName = cfg["RABBITMQ__USER"] ?? "guest",
-        Password = cfg["RABBITMQ__PASSWORD"] ?? "guest",
-        QueueName = cfg["RABBITMQ__QUEUE"] ?? "video-jobs"
-    }));
+        opt.HostName = cfg["RABBITMQ__HOST"] ?? opt.HostName;
+        opt.UserName = cfg["RABBITMQ__USER"] ?? opt.UserName;
+        opt.Password = cfg["RABBITMQ__PASSWORD"] ?? opt.Password;
+        opt.QueueName = cfg["RABBITMQ__QUEUE"] ?? opt.QueueName;
+    })
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
 
-// SignalR
+builder.Services
+    .AddOptions<UploadOptions>()
+    .BindConfiguration("Upload")
+    .Configure(options =>
+    {
+        options.RootPath = cfg["UPLOAD__ROOT_PATH"] ?? cfg["UPLOAD_PATH"] ?? options.RootPath;
+        if (long.TryParse(cfg["UPLOAD__MAX_FILE_SIZE_BYTES"] ?? cfg["UPLOAD__MAX_BYTES"], out var maxBytes) && maxBytes > 0)
+        {
+            options.MaxFileSizeBytes = maxBytes;
+        }
+
+        var allowedExtensions = cfg["UPLOAD__ALLOWED_EXTENSIONS"];
+        if (!string.IsNullOrWhiteSpace(allowedExtensions))
+        {
+            options.AllowedExtensions = allowedExtensions
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+        }
+    })
+    .PostConfigure(options => options.Normalize())
+    .ValidateDataAnnotations()
+    .Validate(options => options.MaxFileSizeBytes > 0, "O tamanho máximo do arquivo deve ser maior que zero.")
+    .ValidateOnStart();
+
+builder.Services.AddSingleton<IConnectionMultiplexer>(_ =>
+{
+    var redisConfiguration = cfg["REDIS__CONNECTION"] ?? "redis:6379";
+    var options = ConfigurationOptions.Parse(redisConfiguration);
+    options.AbortOnConnectFail = false;
+    options.ConnectRetry = 3;
+    options.ClientName = "VisionaryAnalytics.Api";
+    return ConnectionMultiplexer.Connect(options);
+});
+
+builder.Services.AddSingleton<IVideoJobStore, RedisVideoJobStore>();
+builder.Services.AddSingleton<IRabbitMqPublisher, RabbitMqPublisher>();
+
 builder.Services.AddSignalR();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddHealthChecks();
 
 var app = builder.Build();
+
+var uploadOptions = app.Services.GetRequiredService<IOptions<UploadOptions>>().Value;
+Directory.CreateDirectory(uploadOptions.RootPath);
+
 app.UseSwagger();
 app.UseSwaggerUI();
+app.UseHttpsRedirection();
 
 app.MapHealthChecks("/health");
 
-// Hub para notificações
-app.MapHub<ProcessingHub>("/hubs/processing");
+app.MapHub<ProcessingHub>("/hubs/processamento");
 
-// Upload de vídeo
-app.MapPost("/videos", async (HttpRequest req, IRabbitMqPublisher bus, IVideoJobStore store) =>
+app.MapPost("/videos", async (HttpRequest req, IRabbitMqPublisher bus, IVideoJobStore store, IOptions<UploadOptions> uploadOptionsAccessor, CancellationToken cancellationToken) =>
 {
-    if (!req.HasFormContentType) return Results.BadRequest("Form-data required");
+    if (!req.HasFormContentType)
+    {
+        return Results.BadRequest("É necessário enviar o conteúdo como form-data.");
+    }
 
-    var form = await req.ReadFormAsync();
+    var form = await req.ReadFormAsync(cancellationToken).ConfigureAwait(false);
     var file = form.Files.GetFile("file");
-    if (file is null || file.Length == 0) return Results.BadRequest("Arquivo ausente");
+    if (file is null || file.Length == 0)
+    {
+        return Results.BadRequest("Arquivo ausente");
+    }
 
-    var ext = Path.GetExtension(file.FileName).ToLowerInvariant();
-    if (ext is not (".mp4" or ".avi")) return Results.BadRequest("Formatos suportados: .mp4, .avi");
+    var options = uploadOptionsAccessor.Value;
+    if (file.Length > options.MaxFileSizeBytes)
+    {
+        return Results.BadRequest($"Arquivo excede o tamanho máximo permitido de {options.MaxFileSizeBytes} bytes.");
+    }
+
+    var ext = Path.GetExtension(file.FileName);
+    if (string.IsNullOrWhiteSpace(ext))
+    {
+        return Results.BadRequest("Formato de arquivo inválido.");
+    }
+
+    var normalizedExt = ext.ToLowerInvariant();
+    if (!options.AllowedExtensionsSet.Contains(normalizedExt))
+    {
+        var allowed = string.Join(", ", options.AllowedExtensionsSet.OrderBy(static e => e, StringComparer.OrdinalIgnoreCase));
+        return Results.BadRequest($"Formatos suportados: {allowed}");
+    }
 
     var jobId = Guid.NewGuid();
-    var dest = Path.Combine(uploadPath, $"{jobId}{ext}");
-    await using (var fs = File.Create(dest))
-        await file.CopyToAsync(fs);
+    var destinationPath = Path.Combine(options.RootPath, $"{jobId}{normalizedExt}");
 
-    var fps = double.TryParse(form["fps"], out var f) ? Math.Max(1, f) : 5.0;
+    await using (var fs = new FileStream(destinationPath, new FileStreamOptions
+    {
+        Mode = FileMode.CreateNew,
+        Access = FileAccess.Write,
+        Share = FileShare.None,
+        Options = FileOptions.Asynchronous | FileOptions.SequentialScan
+    }))
+    {
+        await file.CopyToAsync(fs, cancellationToken).ConfigureAwait(false);
+    }
 
-    await store.InitAsync(jobId, file.FileName, fps);
-    await bus.PublishAsync(new VideoJobMessage(jobId, dest, fps));
+    var fpsValue = form["fps"].ToString();
+    var fps = TryParseFps(fpsValue, out var parsedFps) ? parsedFps : 5.0d;
+
+    var safeFileName = Path.GetFileName(file.FileName);
+    var correlationId = req.Headers.TryGetValue("X-Correlation-ID", out var correlationHeader)
+        ? correlationHeader.ToString()
+        : req.HttpContext.TraceIdentifier;
+
+    await store.InitAsync(jobId, safeFileName, fps).ConfigureAwait(false);
+    await bus.PublishAsync(new VideoJobMessage(jobId, destinationPath, fps, correlationId), cancellationToken).ConfigureAwait(false);
 
     return Results.Ok(new
     {
         jobId,
         statusEndpoint = $"/videos/{jobId}/status",
         resultsEndpoint = $"/videos/{jobId}/results",
-        signalRHub = "/hubs/processing"
+        signalRHub = "/hubs/processamento"
     });
 });
 
-// Status
 app.MapGet("/videos/{jobId:guid}/status", async (Guid jobId, IVideoJobStore store) =>
 {
-    var status = await store.GetStatusAsync(jobId);
+    var status = await store.GetStatusAsync(jobId).ConfigureAwait(false);
     return status is null
         ? Results.NotFound()
         : Results.Ok(new { jobId, status });
 });
 
-// Resultados
 app.MapGet("/videos/{jobId:guid}/results", async (Guid jobId, IVideoJobStore store) =>
 {
-    var status = await store.GetStatusAsync(jobId);
-    if (status is null) return Results.NotFound();
+    var status = await store.GetStatusAsync(jobId).ConfigureAwait(false);
+    if (status is null)
+    {
+        return Results.NotFound();
+    }
 
-    var results = await store.GetResultsAsync(jobId);
+    var results = await store.GetResultsAsync(jobId).ConfigureAwait(false);
     return Results.Ok(new
     {
         jobId,
@@ -97,3 +174,15 @@ app.MapGet("/videos/{jobId:guid}/results", async (Guid jobId, IVideoJobStore sto
 });
 
 app.Run();
+
+static bool TryParseFps(string? value, out double fps)
+{
+    if (!string.IsNullOrWhiteSpace(value) && double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+    {
+        fps = Math.Clamp(parsed, 1d, 120d);
+        return true;
+    }
+
+    fps = 0;
+    return false;
+}

--- a/VisionaryAnalytics.Api/appsettings.Development.json
+++ b/VisionaryAnalytics.Api/appsettings.Development.json
@@ -4,5 +4,19 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "RabbitMq": {
+    "HostName": "rabbitmq",
+    "UserName": "guest",
+    "Password": "guest",
+    "QueueName": "video-jobs"
+  },
+  "Upload": {
+    "RootPath": "/data/videos",
+    "MaxFileSizeBytes": 524288000,
+    "AllowedExtensions": [
+      ".mp4",
+      ".avi"
+    ]
   }
 }

--- a/VisionaryAnalytics.Api/appsettings.json
+++ b/VisionaryAnalytics.Api/appsettings.json
@@ -5,5 +5,19 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "RabbitMq": {
+    "HostName": "rabbitmq",
+    "UserName": "guest",
+    "Password": "guest",
+    "QueueName": "video-jobs"
+  },
+  "Upload": {
+    "RootPath": "/data/videos",
+    "MaxFileSizeBytes": 524288000,
+    "AllowedExtensions": [
+      ".mp4",
+      ".avi"
+    ]
+  },
   "AllowedHosts": "*"
 }

--- a/VisionaryAnalytics.Infrastructure/Interface/IRabbitMqPublisher.cs
+++ b/VisionaryAnalytics.Infrastructure/Interface/IRabbitMqPublisher.cs
@@ -1,6 +1,8 @@
+using System.Threading;
+
 namespace VisionaryAnalytics.Infrastructure.Interface;
 
 public interface IRabbitMqPublisher
 {
-    Task PublishAsync<T>(T message);
+    Task PublishAsync<T>(T message, CancellationToken cancellationToken = default);
 }

--- a/VisionaryAnalytics.Infrastructure/Rabbit/RabbitMQOptions.cs
+++ b/VisionaryAnalytics.Infrastructure/Rabbit/RabbitMQOptions.cs
@@ -1,9 +1,22 @@
-﻿namespace VisionaryAnalytics.Infrastructure.Rabbit;
+using System.ComponentModel.DataAnnotations;
+
+namespace VisionaryAnalytics.Infrastructure.Rabbit;
 
 public record RabbitMqOptions
 {
-    public string HostName { get; init; } = "rabbitmq";
-    public string UserName { get; init; } = "guest";
-    public string Password { get; init; } = "guest";
-    public string QueueName { get; init; } = "video-jobs";
+    [Required]
+    [MinLength(1)]
+    public string HostName { get; set; } = "rabbitmq";
+
+    [Required]
+    [MinLength(1)]
+    public string UserName { get; set; } = "guest";
+
+    [Required]
+    [MinLength(1)]
+    public string Password { get; set; } = "guest";
+
+    [Required]
+    [MinLength(1)]
+    public string QueueName { get; set; } = "video-jobs";
 }

--- a/VisionaryAnalytics.Infrastructure/Rabbit/RabbitMqPublisher.cs
+++ b/VisionaryAnalytics.Infrastructure/Rabbit/RabbitMqPublisher.cs
@@ -1,49 +1,116 @@
-using RabbitMQ.Client;
-using System.Text;
+using System;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RabbitMQ.Client;
 using VisionaryAnalytics.Infrastructure.Interface;
 
 namespace VisionaryAnalytics.Infrastructure.Rabbit;
 
-public class RabbitMqPublisher : IRabbitMqPublisher, IAsyncDisposable
+public sealed class RabbitMqPublisher : IRabbitMqPublisher, IAsyncDisposable
 {
-    private readonly IConnection _conn;
-    private readonly IModel _ch;
-    private readonly RabbitMqOptions _opt;
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
 
-    public RabbitMqPublisher(RabbitMqOptions opt)
+    private readonly Lazy<IConnection> _connectionFactory;
+    private readonly Lazy<IModel> _channelFactory;
+    private readonly ILogger<RabbitMqPublisher> _logger;
+    private readonly RabbitMqOptions _options;
+
+    public RabbitMqPublisher(IOptions<RabbitMqOptions> options, ILogger<RabbitMqPublisher> logger)
     {
-        _opt = opt;
+        _logger = logger;
+        _options = options.Value;
+        _connectionFactory = new Lazy<IConnection>(CreateConnection, LazyThreadSafetyMode.ExecutionAndPublication);
+        _channelFactory = new Lazy<IModel>(CreateChannel, LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    public Task PublishAsync<T>(T message, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var channel = _channelFactory.Value;
+        var payload = JsonSerializer.SerializeToUtf8Bytes(message, SerializerOptions);
+        var props = channel.CreateBasicProperties();
+        props.DeliveryMode = 2;
+        props.ContentType = "application/json";
+
+        channel.BasicPublish(
+            exchange: string.Empty,
+            routingKey: _options.QueueName,
+            mandatory: false,
+            basicProperties: props,
+            body: payload);
+
+        _logger.LogDebug("Mensagem publicada na fila {QueueName}", _options.QueueName);
+        return Task.CompletedTask;
+    }
+
+    private IConnection CreateConnection()
+    {
         var factory = new ConnectionFactory
         {
-            HostName = opt.HostName,
-            UserName = opt.UserName,
-            Password = opt.Password
+            HostName = _options.HostName,
+            UserName = _options.UserName,
+            Password = _options.Password,
+            DispatchConsumersAsync = false,
+            AutomaticRecoveryEnabled = true
         };
-        _conn = factory.CreateConnection();
-        _ch = _conn.CreateModel();
-        _ch.QueueDeclare(
-            queue: opt.QueueName,
+
+        _logger.LogInformation("Estabelecendo conexão RabbitMQ com {Host}", _options.HostName);
+        return factory.CreateConnection("VisionaryAnalytics.Publisher");
+    }
+
+    private IModel CreateChannel()
+    {
+        var channel = _connectionFactory.Value.CreateModel();
+        channel.QueueDeclare(
+            queue: _options.QueueName,
             durable: true,
             exclusive: false,
             autoDelete: false,
-            arguments: null
-        );
-    }
+            arguments: null);
 
-    public Task PublishAsync<T>(T message)
-    {
-        var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(message));
-        var props = _ch.CreateBasicProperties();
-        props.DeliveryMode = 2;
-        _ch.BasicPublish("", _opt.QueueName, props, body);
-        return Task.CompletedTask;
+        return channel;
     }
 
     public ValueTask DisposeAsync()
     {
-        _ch?.Dispose();
-        _conn?.Dispose();
+        if (_channelFactory.IsValueCreated)
+        {
+            var channel = _channelFactory.Value;
+            try
+            {
+                channel.Close();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Falha ao encerrar o canal RabbitMQ corretamente");
+            }
+            finally
+            {
+                channel.Dispose();
+            }
+        }
+
+        if (_connectionFactory.IsValueCreated)
+        {
+            var connection = _connectionFactory.Value;
+            try
+            {
+                connection.Close();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Falha ao encerrar a conexão RabbitMQ corretamente");
+            }
+            finally
+            {
+                connection.Dispose();
+            }
+        }
+
         return ValueTask.CompletedTask;
     }
 }

--- a/VisionaryAnalytics.Infrastructure/Redis/RedisVideoJobStore.cs
+++ b/VisionaryAnalytics.Infrastructure/Redis/RedisVideoJobStore.cs
@@ -1,5 +1,6 @@
-using StackExchange.Redis;
+using System.IO;
 using System.Text.Json;
+using StackExchange.Redis;
 using VisionaryAnalytics.Infrastructure.Interface;
 
 namespace VisionaryAnalytics.Infrastructure.Redis;
@@ -17,12 +18,13 @@ public class RedisVideoJobStore(IConnectionMultiplexer mux) : IVideoJobStore
     public async Task InitAsync(Guid jobId, string fileName, double fps)
     {
         var db = _mux.GetDatabase();
-        await db.StringSetAsync(KeyStatus(jobId), "Queued");
+        var safeFileName = Path.GetFileName(fileName);
+        await db.StringSetAsync(KeyStatus(jobId), "NaFila");
         await db.HashSetAsync(KeyMeta(jobId), new HashEntry[]
         {
-            new("filename", fileName),
+            new("nomeArquivo", safeFileName),
             new("fps", fps.ToString()),
-            new("createdAt", DateTimeOffset.UtcNow.ToString("O"))
+            new("criadoEm", DateTimeOffset.UtcNow.ToString("O"))
         });
         await db.KeyDeleteAsync(KeyResults(jobId));
     }

--- a/VisionaryAnalytics.Worker/Notifications/IProcessingNotifier.cs
+++ b/VisionaryAnalytics.Worker/Notifications/IProcessingNotifier.cs
@@ -2,5 +2,5 @@ namespace VisionaryAnalytics.Worker.Notifications;
 
 public interface IProcessingNotifier
 {
-    Task NotifyCompletedAsync(Guid jobId, int resultsCount, CancellationToken cancellationToken = default);
+    Task NotificarConclusaoAsync(Guid jobId, int resultsCount, CancellationToken cancellationToken = default);
 }

--- a/VisionaryAnalytics.Worker/Notifications/SignalRProcessingNotifier.cs
+++ b/VisionaryAnalytics.Worker/Notifications/SignalRProcessingNotifier.cs
@@ -15,7 +15,7 @@ public sealed class SignalRProcessingNotifier : IProcessingNotifier, IAsyncDispo
         _logger = logger;
         var hubUrl = configuration["SIGNALR__HUB_URL"]
             ?? configuration.GetSection("SignalR")["HubUrl"]
-            ?? "http://localhost:8080/hubs/processing";
+            ?? "http://localhost:8080/hubs/processamento";
 
         _connection = new HubConnectionBuilder()
             .WithUrl(hubUrl)
@@ -23,17 +23,17 @@ public sealed class SignalRProcessingNotifier : IProcessingNotifier, IAsyncDispo
             .Build();
     }
 
-    public async Task NotifyCompletedAsync(Guid jobId, int resultsCount, CancellationToken cancellationToken = default)
+    public async Task NotificarConclusaoAsync(Guid jobId, int resultsCount, CancellationToken cancellationToken = default)
     {
         try
         {
             await EnsureConnectedAsync(cancellationToken).ConfigureAwait(false);
-            await _connection.InvokeAsync("NotifyCompleted", jobId, resultsCount, cancellationToken)
+            await _connection.InvokeAsync("NotificarConclusao", jobId, resultsCount, cancellationToken)
                 .ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to notify completion for job {JobId}", jobId);
+            _logger.LogError(ex, "Falha ao notificar a conclusão do job {JobId}", jobId);
         }
     }
 

--- a/VisionaryAnalytics.Worker/Processing/VideoProcessingService.cs
+++ b/VisionaryAnalytics.Worker/Processing/VideoProcessingService.cs
@@ -56,7 +56,7 @@ public sealed class VideoProcessingService
 
             if (files.Length == 0)
             {
-                _logger.LogWarning("No frames extracted for job {JobId}", job.JobId);
+                _logger.LogWarning("Nenhum frame extraído para o job {JobId}", job.JobId);
                 return Array.Empty<VideoJobResult>();
             }
 
@@ -84,7 +84,7 @@ public sealed class VideoProcessingService
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Failed to analyze frame {Frame} for job {JobId}", frame.path, job.JobId);
+                    _logger.LogWarning(ex, "Falha ao analisar o frame {Frame} do job {JobId}", frame.path, job.JobId);
                 }
             });
 
@@ -103,11 +103,11 @@ public sealed class VideoProcessingService
             }
             catch (IOException ex)
             {
-                _logger.LogDebug(ex, "Failed to clean temporary directory for job {JobId}", job.JobId);
+                _logger.LogDebug(ex, "Falha ao limpar o diretório temporário do job {JobId}", job.JobId);
             }
             catch (UnauthorizedAccessException ex)
             {
-                _logger.LogDebug(ex, "Unauthorized deleting temporary directory for job {JobId}", job.JobId);
+                _logger.LogDebug(ex, "Sem permissão para remover o diretório temporário do job {JobId}", job.JobId);
             }
         }
     }


### PR DESCRIPTION
## Summary
- enforce typed configuration for RabbitMQ and uploads, including validation and secure defaults
- add upload sanitization, size limits, and correlation metadata before dispatching jobs
- harden worker message processing with improved JSON handling, missing file checks, and resilient RabbitMQ usage
- translate API responses, worker logging/status values, and SignalR hub contracts to português, including the default hub route

## Testing
- not run (dotnet CLI not available in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d977c821c88333a76ad755c370e72d