### PR TITLE
Traduzir mensagens e modelos para português

### DIFF
--- a/VisionaryAnalytics.Api/Program.cs
+++ b/VisionaryAnalytics.Api/Program.cs
@@ -57,7 +57,7 @@ app.MapPost("/videos", async (HttpRequest request, IRabbitMqPublisher bus, IVide
 {
     if (!request.HasFormContentType)
     {
-        return Results.BadRequest("Form-data required");
+        return Results.BadRequest("É necessário enviar os dados no formato form-data");
     }
 
     var form = await request.ReadFormAsync(cancellationToken);
@@ -110,7 +110,7 @@ app.MapGet("/videos/{jobId:guid}/status", async (Guid jobId, IVideoJobStore stor
     {
         jobId,
         status = state.Status,
-        errorMessage = state.ErrorMessage,
+        errorMessage = state.MensagemErro,
         metadata
     });
 });
@@ -136,7 +136,7 @@ app.MapGet("/videos/{jobId:guid}/results", async (Guid jobId, IVideoJobStore sto
     {
         jobId,
         status = state.Status,
-        errorMessage = state.ErrorMessage,
+        errorMessage = state.MensagemErro,
         metadata,
         results
     });

--- a/VisionaryAnalytics.Infrastructure/Models/VideoJobMetadata.cs
+++ b/VisionaryAnalytics.Infrastructure/Models/VideoJobMetadata.cs
@@ -1,3 +1,3 @@
 namespace VisionaryAnalytics.Infrastructure.Models;
 
-public sealed record VideoJobMetadata(string FileName, double FramesPerSecond, DateTimeOffset CreatedAt);
+public sealed record VideoJobMetadata(string NomeArquivo, double QuadrosPorSegundo, DateTimeOffset CriadoEm);

--- a/VisionaryAnalytics.Infrastructure/Models/VideoJobResult.cs
+++ b/VisionaryAnalytics.Infrastructure/Models/VideoJobResult.cs
@@ -1,3 +1,3 @@
 namespace VisionaryAnalytics.Infrastructure.Models;
 
-public sealed record VideoJobResult(string Content, double TimestampSeconds);
+public sealed record VideoJobResult(string Conteudo, double InstanteSegundos);

--- a/VisionaryAnalytics.Infrastructure/Models/VideoJobState.cs
+++ b/VisionaryAnalytics.Infrastructure/Models/VideoJobState.cs
@@ -1,3 +1,3 @@
 namespace VisionaryAnalytics.Infrastructure.Models;
 
-public sealed record VideoJobState(string Status, string? ErrorMessage);
+public sealed record VideoJobState(string Status, string? MensagemErro);

--- a/VisionaryAnalytics.Infrastructure/Models/VideoJobStatuses.cs
+++ b/VisionaryAnalytics.Infrastructure/Models/VideoJobStatuses.cs
@@ -2,8 +2,8 @@ namespace VisionaryAnalytics.Infrastructure.Models;
 
 public static class VideoJobStatuses
 {
-    public const string Queued = "Queued";
-    public const string Processing = "Processing";
-    public const string Completed = "Completed";
-    public const string Failed = "Failed";
+    public const string Queued = "Na fila";
+    public const string Processing = "Processando";
+    public const string Completed = "Concluído";
+    public const string Failed = "Falhou";
 }

--- a/VisionaryAnalytics.Infrastructure/Redis/RedisVideoJobStore.cs
+++ b/VisionaryAnalytics.Infrastructure/Redis/RedisVideoJobStore.cs
@@ -19,9 +19,9 @@ public class RedisVideoJobStore(IConnectionMultiplexer multiplexer) : IVideoJobS
         await db.HashSetAsync(KeyMeta(jobId),
             new HashEntry[]
             {
-                new("filename", fileName),
+                new("nomeArquivo", fileName),
                 new("fps", fps.ToString("G17", System.Globalization.CultureInfo.InvariantCulture)),
-                new("createdAt", DateTimeOffset.UtcNow.ToString("O"))
+                new("criadoEm", DateTimeOffset.UtcNow.ToString("O"))
             });
     }
 
@@ -57,7 +57,7 @@ public class RedisVideoJobStore(IConnectionMultiplexer multiplexer) : IVideoJobS
     {
         var db = _multiplexer.GetDatabase();
         var payload = JsonSerializer.Serialize(result, SerializerOptions);
-        await db.SortedSetAddAsync(KeyResults(jobId), payload, result.TimestampSeconds);
+        await db.SortedSetAddAsync(KeyResults(jobId), payload, result.InstanteSegundos);
     }
 
     public async Task<IReadOnlyList<VideoJobResult>> GetResultsAsync(Guid jobId, CancellationToken cancellationToken = default)
@@ -96,7 +96,7 @@ public class RedisVideoJobStore(IConnectionMultiplexer multiplexer) : IVideoJobS
         }
 
         var map = values.ToDictionary(x => x.Name.ToString(), x => x.Value.ToString());
-        if (!map.TryGetValue("filename", out var fileName) || !map.TryGetValue("fps", out var fpsRaw))
+        if (!map.TryGetValue("nomeArquivo", out var fileName) || !map.TryGetValue("fps", out var fpsRaw))
         {
             return null;
         }
@@ -105,7 +105,7 @@ public class RedisVideoJobStore(IConnectionMultiplexer multiplexer) : IVideoJobS
             ? parsedFps
             : 0d;
 
-        var createdAt = map.TryGetValue("createdAt", out var createdAtRaw) && DateTimeOffset.TryParse(createdAtRaw, out var parsedCreatedAt)
+        var createdAt = map.TryGetValue("criadoEm", out var createdAtRaw) && DateTimeOffset.TryParse(createdAtRaw, out var parsedCreatedAt)
             ? parsedCreatedAt
             : DateTimeOffset.MinValue;
 

--- a/VisionaryAnalytics.Worker/Notifications/SignalRProcessingNotifier.cs
+++ b/VisionaryAnalytics.Worker/Notifications/SignalRProcessingNotifier.cs
@@ -33,7 +33,7 @@ public sealed class SignalRProcessingNotifier : IProcessingNotifier
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to notify completion for job {JobId}", jobId);
+            _logger.LogWarning(ex, "Falha ao notificar a conclusão do job {JobId}", jobId);
         }
     }
 
@@ -50,7 +50,7 @@ public sealed class SignalRProcessingNotifier : IProcessingNotifier
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to notify failure for job {JobId}", jobId);
+            _logger.LogWarning(ex, "Falha ao notificar a falha do job {JobId}", jobId);
         }
     }
 
@@ -63,7 +63,7 @@ public sealed class SignalRProcessingNotifier : IProcessingNotifier
 
         if (string.IsNullOrWhiteSpace(_options.HubUrl))
         {
-            _logger.LogDebug("SignalR hub URL not configured; skipping notifications");
+            _logger.LogDebug("URL do hub SignalR não configurada; notificações serão ignoradas");
             return false;
         }
 
@@ -92,7 +92,7 @@ public sealed class SignalRProcessingNotifier : IProcessingNotifier
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Unable to connect to SignalR hub at {HubUrl}", _options.HubUrl);
+            _logger.LogWarning(ex, "Não foi possível conectar ao hub SignalR em {HubUrl}", _options.HubUrl);
             return false;
         }
         finally

--- a/VisionaryAnalytics.Worker/Processing/VideoJobProcessor.cs
+++ b/VisionaryAnalytics.Worker/Processing/VideoJobProcessor.cs
@@ -48,7 +48,7 @@ public sealed class VideoJobProcessor : IVideoJobProcessor
             const string errorMessage = "Arquivo de vídeo não encontrado para processamento";
             await _store.SetStatusAsync(message.JobId, VideoJobStatuses.Failed, errorMessage, cancellationToken);
             await _notifier.NotifyFailedAsync(message.JobId, errorMessage, cancellationToken);
-            _logger.LogWarning("Video file {FilePath} not found for job {JobId}", message.FilePath, message.JobId);
+            _logger.LogWarning("Arquivo de vídeo {FilePath} não foi encontrado para o job {JobId}", message.FilePath, message.JobId);
             return 0;
         }
 
@@ -70,7 +70,7 @@ public sealed class VideoJobProcessor : IVideoJobProcessor
 
             if (frames.Length == 0)
             {
-                _logger.LogInformation("No frames extracted for job {JobId}", message.JobId);
+                _logger.LogInformation("Nenhum quadro foi extraído para o job {JobId}", message.JobId);
             }
 
             var results = new ConcurrentBag<VideoJobResult>();
@@ -92,7 +92,7 @@ public sealed class VideoJobProcessor : IVideoJobProcessor
             });
 
             var orderedResults = results
-                .OrderBy(result => result.TimestampSeconds)
+                .OrderBy(result => result.InstanteSegundos)
                 .ToList();
 
             foreach (var result in orderedResults)
@@ -103,13 +103,13 @@ public sealed class VideoJobProcessor : IVideoJobProcessor
             await _store.SetStatusAsync(message.JobId, VideoJobStatuses.Completed, cancellationToken: cancellationToken);
             await _notifier.NotifyCompletedAsync(message.JobId, orderedResults.Count, cancellationToken);
 
-            _logger.LogInformation("Job {JobId} completed. QR codes encontrados: {Count}", message.JobId, orderedResults.Count);
+            _logger.LogInformation("Job {JobId} concluído. QR codes encontrados: {Count}", message.JobId, orderedResults.Count);
 
             return orderedResults.Count;
         }
         catch (OperationCanceledException)
         {
-            _logger.LogInformation("Processing cancelled for job {JobId}", message.JobId);
+            _logger.LogInformation("Processamento cancelado para o job {JobId}", message.JobId);
             throw;
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- traduzir a mensagem de validação da API e os campos de status retornados para português
- localizar modelos compartilhados e chaves do Redis para nomes em português
- atualizar logs do worker e notificações SignalR com textos em português

## Testing
- dotnet test *(falha: comando `dotnet` indisponível no ambiente de execução)*

------
https://chatgpt.com/codex/tasks/task_e_68d98711b4188333bce672d8580b624c